### PR TITLE
rtl8723du: Fix build with CONFIG_CONCURRENT_MODE enabled

### DIFF
--- a/os_dep/ioctl_cfg80211.c
+++ b/os_dep/ioctl_cfg80211.c
@@ -2230,7 +2230,7 @@ u8 rtw_cfg80211_scan_via_buddy(struct adapter *adapt, struct cfg80211_scan_reque
 		struct mlme_priv *buddy_mlmepriv;
 		struct rtw_wdev_priv *buddy_wdev_priv;
 
-		iface = dvobj->adapt[i];
+		iface = dvobj->adapters[i];
 		if (!iface)
 			continue;
 
@@ -2278,7 +2278,7 @@ void rtw_cfg80211_indicate_scan_done_for_buddy(struct adapter *adapt, bool bscan
 	bool indicate_buddy_scan;
 
 	for (i = 0; i < dvobj->iface_nums; i++) {
-		iface = dvobj->adapt[i];
+		iface = dvobj->adapters[i];
 		if ((iface) && rtw_is_adapter_up(iface)) {
 
 			if (iface == adapt)

--- a/os_dep/os_intfs.c
+++ b/os_dep/os_intfs.c
@@ -2503,11 +2503,11 @@ netdev_open_normal_process:
 
 #ifdef CONFIG_CONCURRENT_MODE
 	{
-		struct adapter *secstruct adapter = adapter_to_dvobj(adapt)->adapters[IFACE_ID1];
+		struct adapter *sec_adapter = adapter_to_dvobj(adapt)->adapters[IFACE_ID1];
 
 		#ifndef CONFIG_RTW_DYNAMIC_NDEV
-		if (secstruct adapter && (!secstruct adapter->bup))
-			_netdev_vir_if_open(secstruct adapter->pnetdev);
+		if (sec_adapter && (!sec_adapter->bup))
+			_netdev_vir_if_open(sec_adapter->pnetdev);
 		#endif
 	}
 #endif


### PR DESCRIPTION
A find/replace in bfb9db086094 ("rtl8723du: Convert some typedef
statements into regular enum and struct") was too aggressive.
This fixes the incorrect replacements.

Signed-off-by: Mans Rullgard <mans@mansr.com>