### PR TITLE
rtl8723du: Fix build with CONFIG_CONCURRENT_MODE

### DIFF
--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -3047,7 +3047,7 @@ void start_ap_mode(struct adapter *adapt)
 	pmlmepriv->ext_capab_ie_len = 0;
 
 #ifdef CONFIG_CONCURRENT_MODE
-	psecuritypriv->dot118021x_bmc_cam_id = INVALID_SEC_MAC_CAM_ID;
+	adapt->securitypriv.dot118021x_bmc_cam_id = INVALID_SEC_MAC_CAM_ID;
 #endif
 
 	for (i = 0 ;  i < pstapriv->max_aid; i++)

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -10492,7 +10492,6 @@ bool rtw_port_switch_chk(struct adapter *adapter)
 #ifdef CONFIG_CONCURRENT_MODE
 #ifdef CONFIG_RUNTIME_PORT_SWITCH
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
-	struct pwrctrl_priv *pwrctl = dvobj_to_pwrctl(dvobj);
 	struct adapter *if_port0 = NULL;
 	struct adapter *if_port1 = NULL;
 	struct mlme_ext_info *if_port0_mlmeinfo = NULL;
@@ -13578,6 +13577,7 @@ int rtw_chk_start_clnt_join(struct adapter *adapter, u8 *ch, u8 *bw, u8 *offset)
 		struct mlme_priv *mlme;
 		struct mlme_ext_priv *mlmeext;
 		struct mi_state mstate;
+		bool chbw_allow = true;
 		int i;
 
 		dvobj = adapter_to_dvobj(adapter);

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -3146,7 +3146,6 @@ int pre_recv_entry(union recv_frame *precvframe, u8 *pphy_status)
 			precvframe->u.hdr.adapter = iface;
 	} else   /* Handle BC/MC Packets	*/
 		rtw_mi_buddy_clone_bcmc_packet(primary_adapt, precvframe, pphy_status);
-bypass_concurrent_hdl:
 #endif /* CONFIG_CONCURRENT_MODE */
 
 	/* skip unnecessary bmc data frame for primary adapter */

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -1282,6 +1282,10 @@ void rtw_clean_hw_dk_cam(struct adapter *adapter)
 void flush_all_cam_entry(struct adapter *adapt)
 {
 #ifdef CONFIG_CONCURRENT_MODE
+	struct mlme_ext_priv *pmlmeext = &adapt->mlmeextpriv;
+	struct mlme_ext_info *pmlmeinfo = &(pmlmeext->mlmext_info);
+	struct mlme_priv *pmlmepriv = &(adapt->mlmepriv);
+
 	if (check_fwstate(pmlmepriv, WIFI_STATION_STATE)) {
 		struct sta_priv	*pstapriv = &adapt->stapriv;
 		struct sta_info		*psta;

--- a/hal/hal_com.c
+++ b/hal/hal_com.c
@@ -2650,7 +2650,6 @@ void hw_var_port_switch(struct adapter *adapter)
 	u8 macid_1[6];
 	u8 bssid_1[6];
 
-	u8 hw_port;
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	struct adapter *iface = NULL;
 

--- a/hal/rtl8723d_hal_init.c
+++ b/hal/rtl8723d_hal_init.c
@@ -3798,6 +3798,7 @@ u8 SetHwReg8723D(struct adapter * adapt, u8 variable, u8 *val)
 		u32 i;
 		u8 RetryLimit = 0x01;
 		u32 reg_200, reg_204;
+		u16 val16;
 
 		val16 = RetryLimit << RETRY_LIMIT_SHORT_SHIFT | RetryLimit << RETRY_LIMIT_LONG_SHIFT;
 		rtw_write16(adapt, REG_RL, val16);

--- a/os_dep/ioctl_linux.c
+++ b/os_dep/ioctl_linux.c
@@ -1464,9 +1464,7 @@ static int rtw_wx_set_wap(struct net_device *dev,
 	if (rtw_mi_buddy_check_fwstate(adapt, _FW_UNDER_SURVEY | _FW_UNDER_LINKING)) {
 		RTW_INFO("set bssid, but buddy_intf is under scanning or linking\n");
 
-		ret = -EINVAL;
-
-		goto exit;
+		return -EINVAL;
 	}
 #endif
 


### PR DESCRIPTION
Commit 15ed3a979539 ("rtl8723du: Enable all warnings in Makefile and
fix them") removed a number of unused variables and functions.  Some
of them are, however, used with CONFIG_CONCURRENT_MODE enabled.  Add
them back with appropriate adjustments.  Also remove some additional
unused variables declared inside CONFIG_CONCURRENT_MODE ifdefs.

Signed-off-by: Mans Rullgard <mans@mansr.com>