### PR TITLE
dkms build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,20 @@ endif
 	@/sbin/depmod -a ${KVER}
 	@echo "Please reboot your system"
 
+DRIVER_VERSION = $(shell grep "\#define DRIVERVERSION" include/drv_types.h | awk '{print $$3}' | tr -d v\")
+
+dkms_install:
+	@mkdir -vp /usr/src/$(MODULE_NAME)-$(DRIVER_VERSION)
+	cp -r * /usr/src/$(MODULE_NAME)-$(DRIVER_VERSION)
+	dkms add -m $(MODULE_NAME) -v $(DRIVER_VERSION)
+	+ dkms build -m $(MODULE_NAME) -v $(DRIVER_VERSION)
+	dkms install -m $(MODULE_NAME) -v $(DRIVER_VERSION)
+	dkms status -m $(MODULE_NAME)
+
+dkms_remove:
+	dkms remove $(MODULE_NAME)/$(DRIVER_VERSION) --all
+	rm -rf /usr/src/$(MODULE_NAME)-$(DRIVER_VERSION)
+
 config_r:
 	@echo "make config"
 	/bin/bash script/Configure script/config.in

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,9 +1,5 @@
 PACKAGE_NAME="rtl8723du"
-PACKAGE_VERSION=0.1
-MAKE="make -C $kernel_source_dir M=$dkms_tree/$PACKAGE_NAME/$PACKAGE_VERSION/build"
-CLEAN="make -C $kernel_source_dir clean"
+PACKAGE_VERSION="0.1"
 BUILT_MODULE_NAME[0]="8723du"
 DEST_MODULE_LOCATION[0]="/updates"
-REMAKE_INITRD=no
 AUTOINSTALL=yes
-


### PR DESCRIPTION
Added module version check, dkms_install, and dkms_remove to Makefile. Simplfied dkms.conf to let Makefile handle the build paths etc, and to avoid REMAKE_INITRD deprecation warnings. Adapted from rtl8812au source. Tested dkms install, remove, and install (again) on my laptop.