### PR TITLE
rtl8723du: Fix build with recent kernels

### DIFF
--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -405,7 +405,8 @@ int rtw_regd_init(struct wiphy *wiphy)
 	wiphy->regulatory_flags &= ~REGULATORY_DISABLE_BEACON_HINTS;
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0) && \
+     LINUX_VERSION_CODE <= KERNEL_VERSION(6, 1, 38))
 	wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
 #endif
 


### PR DESCRIPTION
The stable trees from 6.1 onward no longer define the REGULATORY_IGNORE_STALE_KICKOFF flag.